### PR TITLE
Fix power commands, reconnect state sync, and logging

### DIFF
--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -1,5 +1,7 @@
 """Provides connection utilities for communicating with a Kaleidescape Player."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -135,11 +137,8 @@ class KaleidescapePlayer:
                 await self.device.connect()
                 await asyncio.sleep(0.5)
                 self._connected = True
-                # Note: _handle_connected() also calls _sync_full_state() when the
-                # dispatcher fires STATE_CONNECTED. This second call is intentional —
-                # it ensures state is synced before connect() returns. Both calls read
-                # from pykaleidescape's in-memory cache (zero I/O) and
-                # _handle_power_state() skips emitting if unchanged, so it's benign.
+                # Redundant with _handle_connected() but benign — unchanged
+                # values are filtered downstream by filter_changed_attributes().
                 await self._sync_full_state()
                 return True
             except (KaleidescapeError, ConnectionError) as err:
@@ -210,6 +209,7 @@ class KaleidescapePlayer:
                 await writer.drain()
             finally:
                 writer.close()
+                await writer.wait_closed()
         except (OSError, asyncio.TimeoutError) as e:
             _LOG.error("Socket command failed for '%s': %s", message.strip(), e)
 
@@ -427,7 +427,8 @@ class KaleidescapePlayer:
         await self._send_socket_command("01/9/SUBTITLES_NEXT:\r")
         return ucapi.StatusCodes.OK
 
-    async def _on_event(self, event: str, params: list[str] | None = None):
+    async def _on_event(self, event: str, params: list[str] | None = None):  # noqa: ARG002
+        # params: required by dispatcher signature (device events pass fields), intentionally unused.
         """Handle device connection state changes based on incoming event."""
         if event == "":
             return
@@ -535,7 +536,6 @@ class KaleidescapePlayer:
 
     async def _handle_events(self, event: str):
         _LOG.debug("Event received: %s", event)
-        _LOG.debug("OSD: %s", self.device.osd)
         await self._sync_full_state()
 
     def _start_position_updater(self):

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -135,8 +135,8 @@ class KaleidescapePlayer:
             try:
                 await self.device.connect()
                 await asyncio.sleep(0.5)
-                await self._handle_power_state()
                 self._connected = True
+                await self._sync_full_state()
                 return True
             except (KaleidescapeError, ConnectionError) as err:
                 await self.device.disconnect()
@@ -437,7 +437,29 @@ class KaleidescapePlayer:
 
         await asyncio.sleep(1)
 
+        await self._sync_full_state()
+
+    async def _sync_full_state(self):
+        """Sync all device state after (re)connect to avoid stale data."""
+        _LOG.debug("[%s] Performing full state sync", self.device_id)
         await self._handle_power_state()
+        await self._handle_play_status()
+
+        await self._emit_update(
+            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_IMAGE_URL, self.device.movie.cover)
+        await self._emit_update(
+            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_TITLE, self.device.movie.title)
+        await self._emit_update(
+            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_TYPE, self.device.movie.media_type)
+
+        self._position_seconds = self.device.movie.title_location or 0
+        self._last_position_update = time.monotonic()
+        await self._emit_update(
+            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_POSITION, self._position_seconds)
+
+        self._duration_seconds = self.device.movie.title_length or 0
+        await self._emit_update(
+            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_DURATION, self._duration_seconds)
 
     async def _handle_disconnected(self):
         """
@@ -502,28 +524,8 @@ class KaleidescapePlayer:
         await self._emit_update(EntityPrefix.REMOTE.value, MediaAttr.STATE, self.state)
 
     async def _handle_events(self, event: str):
-        _LOG.warning("Event received: %s", event)
-        _LOG.warning("OSD: %s", self.device.osd)
-        await self._handle_power_state()
-        await self._handle_play_status()
-
-        await self._emit_update(
-            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.STATE, self.state)
-        await self._emit_update(
-            EntityPrefix.REMOTE.value, MediaAttr.STATE, self.state)
-        await self._emit_update(
-            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_IMAGE_URL, self.device.movie.cover)
-        await self._emit_update(
-            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_TITLE, self.device.movie.title)
-        await self._emit_update(
-            EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_TYPE, self.device.movie.media_type)
-
-        self._position_seconds = self.device.movie.title_location or 0
-        self._last_position_update = time.monotonic()
-        await self._emit_update(EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_POSITION, self._position_seconds)
-
-        self._duration_seconds = self.device.movie.title_length or 0
-        await self._emit_update(EntityPrefix.MEDIA_PLAYER.value, MediaAttr.MEDIA_DURATION, self._duration_seconds)
+        _LOG.debug("Event received: %s", event)
+        await self._sync_full_state()
 
     def _start_position_updater(self):
         if self._position_updater_task is None or self._position_updater_task.done():

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -197,26 +197,41 @@ class KaleidescapePlayer:
             _LOG.debug("Cannot send command: '%s' device is powered off", message.strip())
             return
 
-        with socket.create_connection((self.host, port), timeout=timeout) as sock:
-            sock.sendall(message.encode("utf-8"))
+        try:
+            with socket.create_connection((self.host, port), timeout=timeout) as sock:
+                sock.sendall(message.encode("utf-8"))
+        except OSError as e:
+            _LOG.error("Socket command failed for '%s': %s", message.strip(), e)
 
     async def power_on(self) -> ucapi.StatusCodes:
         """Power on the device. Reconnects if not currently connected."""
-
-        if self._connected:
+        if not self._connected:
+            return ucapi.StatusCodes.SERVICE_UNAVAILABLE
+        if self._attr_state == MediaStates.ON:
+            _LOG.debug("Device already on, skipping leave_standby")
+            return ucapi.StatusCodes.OK
+        try:
             _LOG.debug("Sending leave_standby...")
             await self.device.leave_standby()
             return ucapi.StatusCodes.OK
-        return ucapi.StatusCodes.SERVICE_UNAVAILABLE
+        except Exception as e:
+            _LOG.error("Failed to power on: %s", e)
+            return ucapi.StatusCodes.SERVER_ERROR
 
-    async def power_off(self)-> ucapi.StatusCodes:
+    async def power_off(self) -> ucapi.StatusCodes:
         """Power off the device. Reconnects if not currently connected."""
-
-        if self._connected:
+        if not self._connected:
+            return ucapi.StatusCodes.SERVICE_UNAVAILABLE
+        if self._attr_state == MediaStates.STANDBY:
+            _LOG.debug("Device already in standby, skipping enter_standby")
+            return ucapi.StatusCodes.OK
+        try:
             _LOG.debug("Sending enter_standby...")
             await self.device.enter_standby()
             return ucapi.StatusCodes.OK
-        return ucapi.StatusCodes.SERVICE_UNAVAILABLE
+        except Exception as e:
+            _LOG.error("Failed to power off: %s", e)
+            return ucapi.StatusCodes.SERVER_ERROR
 
     async def alphabetize_cover_art(self) -> ucapi.StatusCodes:
         """Trigger the 'alphabetize_cover_art' command."""
@@ -402,7 +417,7 @@ class KaleidescapePlayer:
         self._send_socket_command("01/9/SUBTITLES_NEXT:\r")
         return ucapi.StatusCodes.OK
 
-    async def _on_event(self, event: str):
+    async def _on_event(self, event: str, params: dict | None = None):
         """Handle device connection state changes based on incoming event."""
         if event == "":
             return
@@ -489,6 +504,7 @@ class KaleidescapePlayer:
     async def _handle_events(self, event: str):
         _LOG.warning("Event received: %s", event)
         _LOG.warning("OSD: %s", self.device.osd)
+        await self._handle_power_state()
         await self._handle_play_status()
 
         await self._emit_update(

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 import logging
-import socket
 import time
 from asyncio import AbstractEventLoop
 from dataclasses import asdict, dataclass
@@ -136,6 +135,11 @@ class KaleidescapePlayer:
                 await self.device.connect()
                 await asyncio.sleep(0.5)
                 self._connected = True
+                # Note: _handle_connected() also calls _sync_full_state() when the
+                # dispatcher fires STATE_CONNECTED. This second call is intentional —
+                # it ensures state is synced before connect() returns. Both calls read
+                # from pykaleidescape's in-memory cache (zero I/O) and
+                # _handle_power_state() skips emitting if unchanged, so it's benign.
                 await self._sync_full_state()
                 return True
             except (KaleidescapeError, ConnectionError) as err:
@@ -185,7 +189,7 @@ class KaleidescapePlayer:
             _LOG.error("Failed to send command '%s': %s", command, e)
             return ucapi.StatusCodes.SERVER_ERROR
 
-    def _send_socket_command(self, message: str, *, port: int = 10000, timeout: int = 2) -> None:
+    async def _send_socket_command(self, message: str, *, port: int = 10000, timeout: int = 2) -> None:
         """Send a raw socket command to the device if it is powered on.
 
         Args:
@@ -198,9 +202,15 @@ class KaleidescapePlayer:
             return
 
         try:
-            with socket.create_connection((self.host, port), timeout=timeout) as sock:
-                sock.sendall(message.encode("utf-8"))
-        except OSError as e:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, port), timeout=timeout
+            )
+            try:
+                writer.write(message.encode("utf-8"))
+                await writer.drain()
+            finally:
+                writer.close()
+        except (OSError, asyncio.TimeoutError) as e:
             _LOG.error("Socket command failed for '%s': %s", message.strip(), e)
 
     async def power_on(self) -> ucapi.StatusCodes:
@@ -214,7 +224,7 @@ class KaleidescapePlayer:
             _LOG.debug("Sending leave_standby...")
             await self.device.leave_standby()
             return ucapi.StatusCodes.OK
-        except Exception as e:
+        except (KaleidescapeError, ConnectionError, OSError) as e:
             _LOG.error("Failed to power on: %s", e)
             return ucapi.StatusCodes.SERVER_ERROR
 
@@ -229,13 +239,13 @@ class KaleidescapePlayer:
             _LOG.debug("Sending enter_standby...")
             await self.device.enter_standby()
             return ucapi.StatusCodes.OK
-        except Exception as e:
+        except (KaleidescapeError, ConnectionError, OSError) as e:
             _LOG.error("Failed to power off: %s", e)
             return ucapi.StatusCodes.SERVER_ERROR
 
     async def alphabetize_cover_art(self) -> ucapi.StatusCodes:
         """Trigger the 'alphabetize_cover_art' command."""
-        self._send_socket_command("01/7/ALPHABETIZE_COVER_ART:\r")
+        await self._send_socket_command("01/7/ALPHABETIZE_COVER_ART:\r")
         return ucapi.StatusCodes.OK
 
     async def back(self) -> ucapi.StatusCodes:
@@ -252,7 +262,7 @@ class KaleidescapePlayer:
 
     async def collections(self) -> ucapi.StatusCodes:
         """Trigger the 'go movie collections' command."""
-        self._send_socket_command("01/1/GO_MOVIE_COLLECTIONS:\r")
+        await self._send_socket_command("01/1/GO_MOVIE_COLLECTIONS:\r")
         return ucapi.StatusCodes.OK
 
     async def cursor_down(self) -> ucapi.StatusCodes:
@@ -287,12 +297,12 @@ class KaleidescapePlayer:
 
     async def intermission_toggle(self) -> ucapi.StatusCodes:
         """Trigger the 'intermission toggle' command."""
-        self._send_socket_command("01/1/INTERMISSION_TOGGLE:\r")
+        await self._send_socket_command("01/1/INTERMISSION_TOGGLE:\r")
         return ucapi.StatusCodes.OK
 
     async def list(self) -> ucapi.StatusCodes:
         """Trigger the 'go movie list' command."""
-        self._send_socket_command("01/1/GO_MOVIE_LIST:\r")
+        await self._send_socket_command("01/1/GO_MOVIE_LIST:\r")
         return ucapi.StatusCodes.OK
 
     async def media_next_track(self) -> ucapi.StatusCodes:
@@ -333,7 +343,7 @@ class KaleidescapePlayer:
 
     async def menu(self) -> ucapi.StatusCodes:
         """Trigger the 'disc_or_kaleidescape_menu' command."""
-        self._send_socket_command("01/6/DISC_OR_KALEIDESCAPE_MENU:\r")
+        await self._send_socket_command("01/6/DISC_OR_KALEIDESCAPE_MENU:\r")
         return ucapi.StatusCodes.OK
 
     async def movie_covers(self) -> ucapi.StatusCodes:
@@ -346,32 +356,32 @@ class KaleidescapePlayer:
 
     async def page_up(self) -> ucapi.StatusCodes:
         """Trigger the 'page_up' command."""
-        self._send_socket_command("01/6/PAGE_UP:\r")
+        await self._send_socket_command("01/6/PAGE_UP:\r")
         return ucapi.StatusCodes.OK
 
     async def page_up_press(self) -> ucapi.StatusCodes:
         """Trigger the 'page_up_press' command."""
-        self._send_socket_command("01/6/PAGE_UP_PRESS:\r")
+        await self._send_socket_command("01/6/PAGE_UP_PRESS:\r")
         return ucapi.StatusCodes.OK
 
     async def page_up_release(self) -> ucapi.StatusCodes:
         """Trigger the 'page_up_release' command."""
-        self._send_socket_command("01/6/PAGE_UP_RELEASE:\r")
+        await self._send_socket_command("01/6/PAGE_UP_RELEASE:\r")
         return ucapi.StatusCodes.OK
 
     async def page_down(self) -> ucapi.StatusCodes:
         """Trigger the 'page_down' command."""
-        self._send_socket_command("01/6/PAGE_DOWN:\r")
+        await self._send_socket_command("01/6/PAGE_DOWN:\r")
         return ucapi.StatusCodes.OK
 
     async def page_down_press(self) -> ucapi.StatusCodes:
         """Trigger the 'page_down_press' command."""
-        self._send_socket_command("01/6/PAGE_DOWN_PRESS:\r")
+        await self._send_socket_command("01/6/PAGE_DOWN_PRESS:\r")
         return ucapi.StatusCodes.OK
 
     async def page_down_release(self) -> ucapi.StatusCodes:
         """Trigger the 'page_down_release' command."""
-        self._send_socket_command("01/6/PAGE_DOWN_RELEASE:\r")
+        await self._send_socket_command("01/6/PAGE_DOWN_RELEASE:\r")
         return ucapi.StatusCodes.OK
 
     async def play_pause(self) -> ucapi.StatusCodes:
@@ -388,7 +398,7 @@ class KaleidescapePlayer:
 
     async def replay(self) -> ucapi.StatusCodes:
         """Trigger the 'replay' command."""
-        self._send_socket_command("01/6/REPLAY:\r")
+        await self._send_socket_command("01/6/REPLAY:\r")
         return ucapi.StatusCodes.OK
 
     async def rewind(self) -> ucapi.StatusCodes:
@@ -399,25 +409,25 @@ class KaleidescapePlayer:
 
     async def shuffle_cover_art(self) -> ucapi.StatusCodes:
         """Trigger the 'shuffle_cover_art' command."""
-        self._send_socket_command("01/6/SHUFFLE_COVER_ART:\r")
+        await self._send_socket_command("01/6/SHUFFLE_COVER_ART:\r")
         return ucapi.StatusCodes.OK
 
     async def movie_store(self) -> ucapi.StatusCodes:
         """Trigger the 'go_movie_store' command."""
-        self._send_socket_command("01/6/GO_MOVIE_STORE:\r")
+        await self._send_socket_command("01/6/GO_MOVIE_STORE:\r")
         return ucapi.StatusCodes.OK
 
     async def search(self) -> ucapi.StatusCodes:
         """Trigger the 'go_search' command."""
-        self._send_socket_command("01/9/GO_SEARCH:\r")
+        await self._send_socket_command("01/9/GO_SEARCH:\r")
         return ucapi.StatusCodes.OK
 
     async def subtitles(self) -> ucapi.StatusCodes:
         """Trigger the 'subtitles_next' command."""
-        self._send_socket_command("01/9/SUBTITLES_NEXT:\r")
+        await self._send_socket_command("01/9/SUBTITLES_NEXT:\r")
         return ucapi.StatusCodes.OK
 
-    async def _on_event(self, event: str, params: dict | None = None):
+    async def _on_event(self, event: str, params: list[str] | None = None):
         """Handle device connection state changes based on incoming event."""
         if event == "":
             return
@@ -525,6 +535,7 @@ class KaleidescapePlayer:
 
     async def _handle_events(self, event: str):
         _LOG.debug("Event received: %s", event)
+        _LOG.debug("OSD: %s", self.device.osd)
         await self._sync_full_state()
 
     def _start_position_updater(self):

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -2,6 +2,7 @@
 """Kaleidescape Remote Two/3 Integration Driver."""
 
 import logging
+import os
 from typing import Any
 
 import config
@@ -16,6 +17,23 @@ from setup_flow import driver_setup_handler
 from ucapi.media_player import Attributes as MediaAttr
 from ucapi.media_player import States
 from utils import setup_logger
+
+
+class JournaldFormatter(logging.Formatter):
+    """Formatter for journald. Prefixes messages with syslog priority codes."""
+
+    PRIORITY_MAP = {
+        logging.DEBUG: "<6>",     # SD_INFO (Remote doesn't support debug level)
+        logging.INFO: "<5>",      # SD_NOTICE
+        logging.WARNING: "<4>",   # SD_WARNING
+        logging.ERROR: "<3>",     # SD_ERR
+        logging.CRITICAL: "<2>",  # SD_CRIT
+    }
+
+    def format(self, record):
+        priority = self.PRIORITY_MAP.get(record.levelno, "<6>")
+        return f"{priority}{record.name}: {record.getMessage()}"
+
 
 _LOG = logging.getLogger("driver")
 
@@ -278,13 +296,20 @@ async def _async_remove(device: KaleidescapePlayer) -> None:
 async def main():
     """Start the Remote Two integration driver."""
 
-    logging.basicConfig(
-        format=(
-            "%(asctime)s.%(msecs)03d | %(levelname)-8s | "
-            "%(name)-14s | %(message)s"
-        ),
-        datefmt="%Y-%m-%d %H:%M:%S"
-    )
+    if os.getenv("INVOCATION_ID"):
+        # Running under systemd on the Remote: timestamps are added by journald,
+        # use priority-coded formatter so the Remote's log viewer can parse severity.
+        handler = logging.StreamHandler()
+        handler.setFormatter(JournaldFormatter())
+        logging.basicConfig(handlers=[handler])
+    else:
+        logging.basicConfig(
+            format=(
+                "%(asctime)s.%(msecs)03d %(levelname)-8s %(name)s.%(funcName)s: "
+                "%(message)s"
+            ),
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
     setup_logger()
 
     _LOG.debug("Starting driver...")

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -176,9 +176,9 @@ def _configure_new_kaleidescape(info: KaleidescapeInfo, connect: bool = False) -
     :param connect: Whether to initiate connection immediately.
     """
 
-    player = get_device(info.id)
-    if player:
-        player.disconnect()
+    device = get_device(info.id)
+    if device:
+        loop.create_task(device.disconnect())
     else:
         device = KaleidescapePlayer(info.host, device_id=info.id)
 

--- a/intg-kaleidescape/remote.py
+++ b/intg-kaleidescape/remote.py
@@ -144,7 +144,7 @@ class KaleidescapeRemote(Remote):
                             case cmds.INTERMISSION:
                                 status = await self._device.intermission_toggle()
                             case cmds.MENU:
-                                status = await self._device.menu_ks()
+                                status = await self._device.menu()
                             case cmds.MOVIE_COLLECTIONS:
                                 status = await self._device.collections()
                             case cmds.MOVIE_COVERS:

--- a/intg-kaleidescape/setup_flow.py
+++ b/intg-kaleidescape/setup_flow.py
@@ -118,6 +118,7 @@ async def handle_user_data_response(msg: ucapi.UserDataResponse) -> ucapi.SetupA
     _LOG.info(msg)
 
     ip = msg.input_values.get("ip")
+    name = msg.input_values.get("name")
 
     url = f"http://{ip}:8080/description.xml"
     raw_info = fetch_device_info(url)
@@ -130,7 +131,7 @@ async def handle_user_data_response(msg: ucapi.UserDataResponse) -> ucapi.SetupA
         id=sn.replace(" ", ""),
         host=ip,
         location=url,
-        friendly_name=raw_info.get("friendlyName", ""),
+        friendly_name=name or raw_info.get("friendlyName", ""),
         manufacturer=raw_info.get("manufacturer", ""),
         model_name=raw_info.get("modelName", ""),
         serial_number=sn

--- a/intg-kaleidescape/utils.py
+++ b/intg-kaleidescape/utils.py
@@ -18,23 +18,23 @@ from typing import Type
 
 
 def setup_logger():
-    """Get logger from all modules"""
+    """Configure log levels for all integration modules.
 
+    Third-party libraries (ucapi, pykaleidescape) are left unconfigured:
+    - ucapi uses NullHandler, so it's silent unless explicitly enabled.
+    - pykaleidescape inherits WARNING from the root logger.
+    """
     level = os.getenv("UC_LOG_LEVEL", "DEBUG").upper()
 
-    logging.getLogger("ucapi.api").setLevel(level)
-    logging.getLogger("ucapi.entities").setLevel(level)
-    logging.getLogger("ucapi.entity").setLevel(level)
-    logging.getLogger("driver").setLevel(level)
-    logging.getLogger("config").setLevel(level)
-    logging.getLogger("discover").setLevel(level)
-    logging.getLogger("setup_flow").setLevel(level)
-    logging.getLogger("device").setLevel(level)
-    logging.getLogger("remote").setLevel(level)
-    logging.getLogger("media_player").setLevel(level)
-    logging.getLogger("registry").setLevel(level)
-    logging.getLogger("utils").setLevel(level)
-    #logging.getLogger("kaleidescape").setLevel(level)
+    for name in (
+        "driver", "config", "discover", "setup_flow",
+        "device", "remote", "media_player", "registry", "utils",
+    ):
+        logging.getLogger(name).setLevel(level)
+
+    # Uncomment for troubleshooting underlying libraries:
+    # logging.getLogger("ucapi").setLevel(logging.DEBUG)
+    # logging.getLogger("kaleidescape").setLevel(logging.DEBUG)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape==2022.2.6
+pykaleidescape==1.1.3
 requests==2.32.3
 ucapi==0.3.1


### PR DESCRIPTION
## Summary

### Bug Fixes

- **Power on/off commands had no error handling**: `leave_standby()` and `enter_standby()` 
  could raise `KaleidescapeError`, `ConnectionError`, or `OSError` (especially during the 
  TCP reset that Kaleidescape devices perform at power on). These exceptions were unhandled, 
  causing the command to fail silently. Added try/except with proper error logging and 
  `SERVER_ERROR` status codes. Also added idempotency guards to skip redundant power commands 
  when the device is already in the target state.

- **Reconnect only synced power state, not full device state**: After a TCP reconnect 
  (common during power-on), `_handle_connected()` only called `_handle_power_state()`. 
  This left media title, cover art, playback position, duration, and play status stale 
  until the next push event. Extracted `_sync_full_state()` to sync all fields on every 
  reconnect and initial connect.

- **`_send_socket_command` blocked the event loop**: Used synchronous `socket.create_connection()` 
  which blocks the entire asyncio loop for up to the timeout duration. Replaced with 
  `asyncio.open_connection()` and added error handling (previously had none). Updated all 
  14 callers to await the now-async method.

- **`menu_ks()` call in remote.py did not exist**: `remote.py` called `self._device.menu_ks()` 
  but the method on `KaleidescapePlayer` was named `menu()`. This would raise `AttributeError` 
  at runtime. Fixed the call site.

- **`_on_event` crashed on device events**: The pykaleidescape dispatcher passes two arguments 
  for device events (event name + fields list) but only one for connection events. The handler 
  only accepted one parameter, causing a `TypeError` on every device event. Added `params` 
  parameter with a default.

- **`_configure_new_kaleidescape` had an `UnboundLocalError`** (pre-existing on main): When 
  a device was already registered, the `else` branch (which defines `device`) was skipped, 
  but `device` was referenced unconditionally afterward. Also fixed the async `disconnect()` 
  call that was missing `await` in a sync function.

- **Setup form name ignored for entity display names**: The discovery setup form pre-filled 
  the device name from UPnP `friendlyName` and allowed editing, but the user's input was 
  never read. Entity names always used the UPnP name regardless of what the user typed. 
  Now the user-provided name is used when available, falling back to UPnP.

### Improvements

- **Journald-compatible logging**: Added `JournaldFormatter` that prefixes log messages with 
  syslog priority codes (`<2>` through `<6>`) when running under systemd on the Remote. 
  Detected via the `INVOCATION_ID` env var. Local development retains timestamped format 
  with function names. This follows the pattern used by official UC integrations (e.g., 
  [intg-appletv](https://github.com/unfoldedcircle/integration-appletv), 
  [intg-denonavr](https://github.com/unfoldedcircle/integration-denonavr)) and enables 
  severity filtering in the Remote's web configurator log export.

- **Stopped overriding third-party library log levels**: `setup_logger()` was explicitly 
  setting levels on `ucapi.api`, `ucapi.entities`, etc. This overrode their intentional 
  defaults (ucapi uses `NullHandler`, pykaleidescape inherits root). Replaced with a loop 
  over only this integration's own module loggers.

- **pykaleidescape version corrected**: `requirements.txt` referenced `2022.2.6` (year-based 
  versioning scheme). The actual latest release on PyPI is `1.1.3`.

- **Demoted noisy event logging**: `_handle_events` logged at `WARNING` level on every 
  single push event. Changed to `DEBUG`.

## Test plan

- [ ] Power on from standby — verify command succeeds and state updates to ON
- [ ] Power off — verify command succeeds and state updates to STANDBY
- [ ] Power on when already on — verify no command sent, returns OK
- [ ] Power off when already in standby — verify no command sent, returns OK
- [ ] Disconnect/reconnect cycle — verify cover art, title, position, and play status all resync
- [ ] UC standby cycle (ENTER_STANDBY → EXIT_STANDBY) — verify full state restored
- [ ] Socket commands (menu, page up/down, etc.) — verify they still work after async conversion
- [ ] Check Remote log viewer shows correct severity levels
- [ ] Setup with custom name — verify entity names use the user-provided name, not UPnP default

🤖 Generated with [Claude Code](https://claude.com/claude-code)