### PR TITLE
Add HOME command handler for media player entity

### DIFF
--- a/intg-kaleidescape/media_player.py
+++ b/intg-kaleidescape/media_player.py
@@ -114,6 +114,8 @@ class KaleidescapeMediaPlayer(MediaPlayer):
                 res = await self._device.cursor_left()
             case Commands.CURSOR_RIGHT:
                 res = await self._device.cursor_right()
+            case Commands.HOME:
+                res = await self._device.collections()
             case Commands.MENU:
                 res = await self._device.menu()
             case Commands.FAST_FORWARD:


### PR DESCRIPTION
## Summary

Maps the UC `HOME` command to the Kaleidescape `go_movie_collections` action, which navigates to the top-level collections screen — the closest equivalent to a "home" screen on Kaleidescape devices.

The `Features.HOME` flag was already declared in the media player feature list, but the corresponding command handler was missing, causing HOME button presses to return `NOT_IMPLEMENTED`.

## Changes

- Add `Commands.HOME` case in the media player command handler, routing to `self._device.collections()`