### PR TITLE
Bump pykaleidescape to v1.1.5

### DIFF
--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -4,6 +4,8 @@
 import logging
 from typing import Any
 
+import kaleidescape.const as _kscape_const
+
 import config
 import ucapi
 from api import api, loop
@@ -18,6 +20,10 @@ from ucapi.media_player import States
 from utils import setup_logger
 
 _LOG = logging.getLogger("driver")
+
+# Workaround for pykaleidescape KeyError on unmapped error codes.
+# See: https://github.com/SteveEasley/pykaleidescape/issues/13
+_kscape_const.RESPONSE_ERROR.setdefault(28, "Unknown error (28)")
 
 
 @api.listens_to(ucapi.Events.CONNECT)

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -2,10 +2,7 @@
 """Kaleidescape Remote Two/3 Integration Driver."""
 
 import logging
-from collections import defaultdict
 from typing import Any
-
-import kaleidescape.const as _kscape_const
 
 import config
 import ucapi
@@ -21,14 +18,6 @@ from ucapi.media_player import States
 from utils import setup_logger
 
 _LOG = logging.getLogger("driver")
-
-# Temporary workaround: pykaleidescape uses bare dict lookups on RESPONSE_ERROR which
-# raises KeyError for unmapped device error codes, silently killing async event tasks
-# and leaving device state stale. Replace with a defaultdict to handle any unknown code.
-# Remove once upstream fix is released: https://github.com/SteveEasley/pykaleidescape/pull/14
-_kscape_const.RESPONSE_ERROR = defaultdict(
-    lambda: "Unknown error", _kscape_const.RESPONSE_ERROR
-)
 
 
 @api.listens_to(ucapi.Events.CONNECT)

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -2,6 +2,7 @@
 """Kaleidescape Remote Two/3 Integration Driver."""
 
 import logging
+from collections import defaultdict
 from typing import Any
 
 import kaleidescape.const as _kscape_const
@@ -21,9 +22,13 @@ from utils import setup_logger
 
 _LOG = logging.getLogger("driver")
 
-# Workaround for pykaleidescape KeyError on unmapped error codes.
-# See: https://github.com/SteveEasley/pykaleidescape/issues/13
-_kscape_const.RESPONSE_ERROR.setdefault(28, "Unknown error (28)")
+# Temporary workaround: pykaleidescape uses bare dict lookups on RESPONSE_ERROR which
+# raises KeyError for unmapped device error codes, silently killing async event tasks
+# and leaving device state stale. Replace with a defaultdict to handle any unknown code.
+# Remove once upstream fix is released: https://github.com/SteveEasley/pykaleidescape/pull/14
+_kscape_const.RESPONSE_ERROR = defaultdict(
+    lambda: "Unknown error", _kscape_const.RESPONSE_ERROR
+)
 
 
 @api.listens_to(ucapi.Events.CONNECT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.4
+pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.5
 requests==2.32.3
 ucapi==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@49082279a89f45bb1ad47c1ecc4e330f6590024a
+pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.4
 requests==2.32.3
 ucapi==0.3.1


### PR DESCRIPTION
## Summary

Bumps pykaleidescape to v1.1.5, which includes fixes for several issues encountered during integration development.

### Fixes in pykaleidescape v1.1.5

- **`_response_handler` infinite loop on unhandled exceptions** — The broad `except Exception` clause caught errors but didn't exit the loop or trigger reconnect, turning any unexpected exception into infinite error spam (~200 errors/second). Now tears down the connection and lets auto-reconnect start clean.
  - PR: SteveEasley/pykaleidescape#16

- **`Device.disconnect()` not cancelling reconnect task** — `disconnect()` silently did nothing when called during `STATE_RECONNECTING` because the `is_connected` guard prevented `Connection.disconnect()` from being reached. This left the reconnect task running and caused dual-handler race conditions on the next `connect()`.
  - PR: SteveEasley/pykaleidescape#17

- **Crash when OSD highlighted handle is empty** — The library called `get_content_details()` without validating that the highlighted handle was present, sending an invalid request that the device rejected with an unhandled `MessageError`.
  - Issue: SteveEasley/pykaleidescape#15

### Also included (from v1.1.4)

- Handle unmapped error codes with defaultdict instead of raising `KeyError` (SteveEasley/pykaleidescape#14)
- `asyncio.iscoroutinefunction` deprecation fix (SteveEasley/pykaleidescape#7)
- Navigation commands for movie UI flows (SteveEasley/pykaleidescape#12)