### PR TITLE
Fix reconnect lifecycle, reconfigure state sync, and harden event handling

### DIFF
--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -86,8 +86,9 @@ class KaleidescapePlayer:
 
         # Internal connection and media state
         self._connected: bool = False
+        self._connecting: bool = False
+        self._reconnect_task: asyncio.Task | None = None
         self._attr_state = MediaStates.UNAVAILABLE
-        self._stop_retry = asyncio.Event()
 
         # Playback state
         self._position_seconds = 0
@@ -119,51 +120,92 @@ class KaleidescapePlayer:
         return self._attr_state
 
     async def connect(self) -> bool:
-        """Establish a connection to the device with retry logic."""
-        _LOG.debug("Connecting to player")
+        """Connect to the device. The library handles auto-reconnect on drops.
 
+        If the initial connection fails, a background retry task is started
+        that retries until successful or disconnect() is called.
+        """
         if self._connected:
-            _LOG.debug("Already connected disconnecting first")
-            await self.disconnect()
+            _LOG.debug("Already connected to %s", self.host)
+            return True
 
-        self._stop_retry.clear()
-        retry_delay = 1
-        max_delay = 60
+        _LOG.debug("Connecting to player at %s", self.host)
 
-        while not self._stop_retry.is_set():
-            try:
-                await self.device.connect()
-                self._connected = True
-                await asyncio.sleep(0.5)
-                await self._sync_full_state()
-                return True
-            except (KaleidescapeError, ConnectionError, OSError) as err:
-                await self.device.disconnect()
-                _LOG.error("Unable to connect to %s: %s", self.host, err)
-                self._connected = False
+        # UPSTREAM WORKAROUND: Device.disconnect() guards on is_connected which
+        # is False during STATE_RECONNECTING, silently skipping cleanup. Call
+        # Connection.disconnect() directly to reliably cancel any active
+        # reconnect task. Remove once pykaleidescape PR #17 lands and
+        # Device.disconnect() handles all states.
+        await self._cancel_reconnect_task()
+        await self.device.connection.disconnect()
 
-                try:
-                    await asyncio.wait_for(self._stop_retry.wait(), timeout=retry_delay)
-                except asyncio.exceptions.TimeoutError:
-                    pass
-
-                retry_delay = min(retry_delay * 2, max_delay)
-
-        _LOG.debug("Connect aborted due to stop signal")
-        return False
+        self._connecting = True
+        try:
+            await self.device.connect()
+            await self.device.refresh()
+            self._connected = True
+            await self._sync_full_state()
+            return True
+        except (KaleidescapeError, ConnectionError, OSError) as err:
+            _LOG.error("Unable to connect to %s: %s", self.host, err)
+            await self.device.connection.disconnect()
+            self._connected = False
+            self._reconnect_task = asyncio.create_task(self._retry_connect())
+            return False
+        finally:
+            self._connecting = False
 
     async def disconnect(self):
-        """Disconnect from the device and stop any reconnect attempts."""
-        self._stop_retry.set()  # signal reconnect loop to stop
-
-        if self._connected:
-            _LOG.debug("Disconnecting from player")
-            await self.device.disconnect()
-            self._connected = False
-        else:
-            _LOG.debug("Already disconnected skipping")
-
+        """Disconnect from the device and cancel all reconnect activity."""
+        _LOG.debug("Disconnecting from player at %s", self.host)
+        await self._cancel_reconnect_task()
+        self._stop_position_updater()
+        # UPSTREAM WORKAROUND: see comment in connect().
+        await self.device.connection.disconnect()
+        self._connected = False
         await self._handle_power_state()
+
+    async def _cancel_reconnect_task(self):
+        """Cancel the integration-level retry task if running."""
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except asyncio.CancelledError:
+                pass
+            self._reconnect_task = None
+
+    async def _retry_connect(self):
+        """Retry initial connection until successful or cancelled.
+
+        The library's reconnect=True only activates after a successful first
+        connection (by design). This task provides persistent retry for the
+        initial connect failure case at the integration level.
+
+        Runs indefinitely — cancellation is handled by _cancel_reconnect_task()
+        which is called from disconnect() and connect(). There is no automatic
+        give-up because there is no other recovery path for the user.
+        """
+        # UPSTREAM: _reconnect_delay is a private attribute on Connection.
+        # Replace with a public accessor if pykaleidescape exposes one.
+        delay = self.device.connection._reconnect_delay or 5
+        while True:
+            _LOG.debug("Retrying connection to %s in %ss", self.host, delay)
+            await asyncio.sleep(delay)
+            self._connecting = True
+            try:
+                await self.device.connect()
+                await self.device.refresh()
+                self._connected = True
+                await self._sync_full_state()
+                self._reconnect_task = None
+                _LOG.info("Reconnected to %s", self.host)
+                return
+            except (KaleidescapeError, ConnectionError, OSError) as err:
+                _LOG.warning("Retry connect to %s failed: %s", self.host, err)
+                await self.device.connection.disconnect()
+            finally:
+                self._connecting = False
 
     async def send_command(self, command: str) -> ucapi.StatusCodes:
         """Send a command to a device."""
@@ -455,17 +497,37 @@ class KaleidescapePlayer:
         await handler()
 
     async def _handle_connected(self):
+        """Handle library auto-reconnect completion.
+
+        UPSTREAM WORKAROUND: The library dispatches STATE_CONNECTED during both
+        initial connect() and auto-reconnect, but doesn't call refresh() after
+        reconnect. We gate on _connecting to avoid double refresh/sync during
+        initial connect (where connect() already handles it), and only run the
+        full resync on auto-reconnect. Remove the _connecting guard once the
+        library either suppresses the event during initial connect or calls
+        refresh() itself after reconnect.
+        """
         self._connected = True
         self.events.emit(Events.CONNECTED.name, self.device_id)
 
-        await asyncio.sleep(1)
+        if self._connecting:
+            return
+
+        try:
+            await self.device.refresh()
+        except (KaleidescapeError, ConnectionError, OSError) as err:
+            _LOG.warning("Failed to refresh state after reconnect: %s", err)
+
         await self._sync_full_state()
 
     async def _sync_full_state(self) -> None:
         """Sync and emit the full current device state."""
         await self._handle_power_state()
         await self._handle_play_status()
+        await self._sync_media_attributes()
 
+    async def _sync_media_attributes(self) -> None:
+        """Emit current media attributes from the library's dataclasses."""
         await self._emit_update(
             EntityPrefix.MEDIA_PLAYER.value,
             MediaAttr.MEDIA_IMAGE_URL,
@@ -560,9 +622,15 @@ class KaleidescapePlayer:
         await self._emit_update(EntityPrefix.REMOTE.value, MediaAttr.STATE, self.state)
 
     async def _handle_events(self, event: str):
+        """Handle library events by syncing media state.
+
+        The library has already parsed the event and updated its dataclasses
+        before dispatching, so we just read the current values and emit
+        updates for media-related attributes. Power state has its own handler.
+        """
         _LOG.debug("Event received: %s", event)
-        _LOG.debug("OSD: %s", self.device.osd)
-        await self._sync_full_state()
+        await self._handle_play_status()
+        await self._sync_media_attributes()
 
     def _start_position_updater(self):
         if self._position_updater_task is None or self._position_updater_task.done():

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -144,10 +144,6 @@ class KaleidescapePlayer:
         self._connecting = True
         try:
             await self.device.connect()
-            await self.device.refresh()
-            self._connected = True
-            await self._sync_full_state()
-            return True
         except (KaleidescapeError, ConnectionError, OSError) as err:
             _LOG.error("Unable to connect to %s: %s", self.host, err)
             await self.device.disconnect()
@@ -156,6 +152,16 @@ class KaleidescapePlayer:
             return False
         finally:
             self._connecting = False
+
+        self._connected = True
+
+        try:
+            await self.device.refresh()
+        except (KaleidescapeError, ConnectionError, OSError) as err:
+            _LOG.warning("Failed to refresh state after connect: %s", err)
+
+        await self._sync_full_state()
+        return True
 
     async def disconnect(self):
         """Disconnect from the device and cancel all reconnect activity."""
@@ -194,17 +200,24 @@ class KaleidescapePlayer:
             self._connecting = True
             try:
                 await self.device.connect()
-                await self.device.refresh()
-                self._connected = True
-                await self._sync_full_state()
-                self._reconnect_task = None
-                _LOG.info("Reconnected to %s", self.host)
-                return
             except (KaleidescapeError, ConnectionError, OSError) as err:
                 _LOG.warning("Retry connect to %s failed: %s", self.host, err)
                 await self.device.disconnect()
+                continue
             finally:
                 self._connecting = False
+
+            self._connected = True
+
+            try:
+                await self.device.refresh()
+            except (KaleidescapeError, ConnectionError, OSError) as err:
+                _LOG.warning("Failed to refresh state after reconnect: %s", err)
+
+            await self._sync_full_state()
+            self._reconnect_task = None
+            _LOG.info("Reconnected to %s", self.host)
+            return
 
     async def send_command(self, command: str) -> ucapi.StatusCodes:
         """Send a command to a device."""

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -23,6 +23,8 @@ from ucapi.media_player import States as MediaStates
 
 _LOG = logging.getLogger(__name__)
 
+_RECONNECT_DELAY = 5
+
 class Events(IntEnum):
     """Driver lifecycle events used internally for signaling."""
 
@@ -79,7 +81,7 @@ class KaleidescapePlayer:
         # Identity and core connection
         self.device_id = device_id or "unknown"
         self.host = host
-        self.device = KaleidescapeDevice(host, timeout=5, reconnect=True, reconnect_delay=5)
+        self.device = KaleidescapeDevice(host, timeout=5, reconnect=True, reconnect_delay=_RECONNECT_DELAY)
 
         # Event loop setup
         self._event_loop = loop or asyncio.get_running_loop()
@@ -131,13 +133,8 @@ class KaleidescapePlayer:
 
         _LOG.debug("Connecting to player at %s", self.host)
 
-        # UPSTREAM WORKAROUND: Device.disconnect() guards on is_connected which
-        # is False during STATE_RECONNECTING, silently skipping cleanup. Call
-        # Connection.disconnect() directly to reliably cancel any active
-        # reconnect task. Remove once pykaleidescape PR #17 lands and
-        # Device.disconnect() handles all states.
         await self._cancel_reconnect_task()
-        await self.device.connection.disconnect()
+        await self.device.disconnect()
 
         self._connecting = True
         try:
@@ -148,7 +145,7 @@ class KaleidescapePlayer:
             return True
         except (KaleidescapeError, ConnectionError, OSError) as err:
             _LOG.error("Unable to connect to %s: %s", self.host, err)
-            await self.device.connection.disconnect()
+            await self.device.disconnect()
             self._connected = False
             self._reconnect_task = asyncio.create_task(self._retry_connect())
             return False
@@ -160,8 +157,7 @@ class KaleidescapePlayer:
         _LOG.debug("Disconnecting from player at %s", self.host)
         await self._cancel_reconnect_task()
         self._stop_position_updater()
-        # UPSTREAM WORKAROUND: see comment in connect().
-        await self.device.connection.disconnect()
+        await self.device.disconnect()
         self._connected = False
         await self._handle_power_state()
 
@@ -186,9 +182,7 @@ class KaleidescapePlayer:
         which is called from disconnect() and connect(). There is no automatic
         give-up because there is no other recovery path for the user.
         """
-        # UPSTREAM: _reconnect_delay is a private attribute on Connection.
-        # Replace with a public accessor if pykaleidescape exposes one.
-        delay = self.device.connection._reconnect_delay or 5
+        delay = _RECONNECT_DELAY
         while True:
             _LOG.debug("Retrying connection to %s in %ss", self.host, delay)
             await asyncio.sleep(delay)
@@ -203,7 +197,7 @@ class KaleidescapePlayer:
                 return
             except (KaleidescapeError, ConnectionError, OSError) as err:
                 _LOG.warning("Retry connect to %s failed: %s", self.host, err)
-                await self.device.connection.disconnect()
+                await self.device.disconnect()
             finally:
                 self._connecting = False
 
@@ -499,13 +493,14 @@ class KaleidescapePlayer:
     async def _handle_connected(self):
         """Handle library auto-reconnect completion.
 
-        UPSTREAM WORKAROUND: The library dispatches STATE_CONNECTED during both
-        initial connect() and auto-reconnect, but doesn't call refresh() after
-        reconnect. We gate on _connecting to avoid double refresh/sync during
-        initial connect (where connect() already handles it), and only run the
-        full resync on auto-reconnect. Remove the _connecting guard once the
-        library either suppresses the event during initial connect or calls
-        refresh() itself after reconnect.
+        The library dispatches STATE_CONNECTED during both initial connect()
+        and auto-reconnect, and doesn't refresh device state after reconnect.
+        We gate on _connecting to avoid running refresh/sync while
+        Device.connect() is still populating device info.
+
+        Pending upstream: pykaleidescape PR #18 (auto-refresh after reconnect)
+        and PR #19 (suppress signal during initial connect) would let us
+        remove the _connecting guard and simplify this to just _sync_full_state().
         """
         self._connected = True
         self.events.emit(Events.CONNECTED.name, self.device_id)

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -112,6 +112,11 @@ class KaleidescapePlayer:
         return updated_data
 
     @property
+    def connected(self) -> bool:
+        """Return true if device is connected."""
+        return self._connected
+
+    @property
     def is_on(self) -> bool:
         """Return true if device is on."""
         return self.device.power.state == DEVICE_POWER_STATE_ON

--- a/intg-kaleidescape/device.py
+++ b/intg-kaleidescape/device.py
@@ -88,7 +88,6 @@ class KaleidescapePlayer:
 
         # Internal connection and media state
         self._connected: bool = False
-        self._connecting: bool = False
         self._reconnect_task: asyncio.Task | None = None
         self._attr_state = MediaStates.UNAVAILABLE
 
@@ -141,7 +140,6 @@ class KaleidescapePlayer:
         await self._cancel_reconnect_task()
         await self.device.disconnect()
 
-        self._connecting = True
         try:
             await self.device.connect()
         except (KaleidescapeError, ConnectionError, OSError) as err:
@@ -150,16 +148,9 @@ class KaleidescapePlayer:
             self._connected = False
             self._reconnect_task = asyncio.create_task(self._retry_connect())
             return False
-        finally:
-            self._connecting = False
 
         self._connected = True
-
-        try:
-            await self.device.refresh()
-        except (KaleidescapeError, ConnectionError, OSError) as err:
-            _LOG.warning("Failed to refresh state after connect: %s", err)
-
+        await self.device.refresh()
         await self._sync_full_state()
         return True
 
@@ -197,23 +188,15 @@ class KaleidescapePlayer:
         while True:
             _LOG.debug("Retrying connection to %s in %ss", self.host, delay)
             await asyncio.sleep(delay)
-            self._connecting = True
             try:
                 await self.device.connect()
             except (KaleidescapeError, ConnectionError, OSError) as err:
                 _LOG.warning("Retry connect to %s failed: %s", self.host, err)
                 await self.device.disconnect()
                 continue
-            finally:
-                self._connecting = False
 
             self._connected = True
-
-            try:
-                await self.device.refresh()
-            except (KaleidescapeError, ConnectionError, OSError) as err:
-                _LOG.warning("Failed to refresh state after reconnect: %s", err)
-
+            await self.device.refresh()
             await self._sync_full_state()
             self._reconnect_task = None
             _LOG.info("Reconnected to %s", self.host)
@@ -511,26 +494,12 @@ class KaleidescapePlayer:
     async def _handle_connected(self):
         """Handle library auto-reconnect completion.
 
-        The library dispatches STATE_CONNECTED during both initial connect()
-        and auto-reconnect, and doesn't refresh device state after reconnect.
-        We gate on _connecting to avoid running refresh/sync while
-        Device.connect() is still populating device info.
-
-        Pending upstream: pykaleidescape PR #18 (auto-refresh after reconnect)
-        and PR #19 (suppress signal during initial connect) would let us
-        remove the _connecting guard and simplify this to just _sync_full_state().
+        The library only dispatches STATE_CONNECTED on auto-reconnect (not
+        during initial connect) and refreshes device state before dispatching,
+        so we just need to sync the integration-level state.
         """
         self._connected = True
         self.events.emit(Events.CONNECTED.name, self.device_id)
-
-        if self._connecting:
-            return
-
-        try:
-            await self.device.refresh()
-        except (KaleidescapeError, ConnectionError, OSError) as err:
-            _LOG.warning("Failed to refresh state after reconnect: %s", err)
-
         await self._sync_full_state()
 
     async def _sync_full_state(self) -> None:

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -90,6 +90,12 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
             _LOG.error("Failed to subscribe entities: no Kaleidescape configuration found for %s", device_id)
         return
 
+    # After reconfigure the Remote won't send a new connect event (it's
+    # already connected), but the device was recreated without connecting.
+    # Kick off a connect so state eventually resolves from UNAVAILABLE.
+    if not device._connected:
+        loop.create_task(device.connect())
+
     for entity_id in entity_ids:
         _LOG.debug("entity id = %s", entity_id)
         entity = api.configured_entities.get(entity_id)
@@ -256,6 +262,8 @@ def on_player_removed(player_info: KaleidescapeInfo | None) -> None:
     """Handle removal of a Kaleidescape Player from config."""
     if player_info is None:
         _LOG.info("All devices cleared from config.")
+        for device in list(all_devices().values()):
+            loop.create_task(_async_remove(device))
         clear_devices()
         api.configured_entities.clear()
         api.available_entities.clear()

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -93,7 +93,7 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
     # After reconfigure the Remote won't send a new connect event (it's
     # already connected), but the device was recreated without connecting.
     # Kick off a connect so state eventually resolves from UNAVAILABLE.
-    if not device._connected:
+    if not device.connected:
         loop.create_task(device.connect())
 
     for entity_id in entity_ids:

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -160,7 +160,10 @@ def _configure_new_kaleidescape(info: KaleidescapeInfo, connect: bool = False) -
     """
 
     async def _reconfigure_existing_device(device: KaleidescapePlayer) -> None:
-        await device.disconnect()
+        try:
+            await device.disconnect()
+        except Exception as err:
+            _LOG.error("Failed to disconnect during reconfigure: %s", err)
         if connect:
             await device.connect()
 

--- a/intg-kaleidescape/registry.py
+++ b/intg-kaleidescape/registry.py
@@ -67,7 +67,7 @@ async def connect_all() -> None:
     """
     Connect all registered Kaleidescape Player instances asynchronously.
     """
-    for device in iter_devices():
+    for device in list(iter_devices()):
         await device.connect()
 
 
@@ -75,7 +75,7 @@ async def disconnect_all() -> None:
     """
     Disconnect all registered Kaleidescape Player instances asynchronously.
     """
-    for device in iter_devices():
+    for device in list(iter_devices()):
         await device.disconnect()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@49082279a89f45bb1ad47c1ecc4e330f6590024a
+pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.5
 requests==2.32.3
 ucapi==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.6
+pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@49082279a89f45bb1ad47c1ecc4e330f6590024a
 requests==2.32.3
 ucapi==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@49082279a89f45bb1ad47c1ecc4e330f6590024a
+pykaleidescape @ git+https://github.com/robotdan/pykaleidescape.git@74f4d0e935f39c6cb46cddca26516d1351d777af
 requests==2.32.3
 ucapi==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.5
+pykaleidescape @ git+https://github.com/SteveEasley/pykaleidescape.git@v1.1.6
 requests==2.32.3
 ucapi==0.3.1


### PR DESCRIPTION
## Summary

Follows up on the reconnect and state sync work from commits `82d3b39`..`91543c5`. Testing revealed a reconnect race condition, a device leak during reconfigure, and redundant work in the event handler.

- Bump pykaleidescape to v1.1.6, which auto-refreshes state after reconnect (#18), only dispatches STATE_CONNECTED on auto-reconnect (#19), and handles partial query failures in refresh() (#20) — removing the need for the `_connecting` guard flag, manual refresh in the connected handler, and defensive try/except around refresh calls
- Replace the reconnect retry loop with a cancellable async task, fixing a race where `connect()` tore down a working connection and `disconnect()` didn't wait for the loop to stop
- Narrow `_handle_events` to only sync media attributes and play status since power state already has its own dedicated handler
- Disconnect and remove listeners from old devices during reconfigure before clearing the registry — previously the old TCP connection stayed alive, receiving events and pushing stale state that raced with the new device's state sync
- Connect the device when `on_subscribe_entities` finds it unconnected, since the Remote won't send a new `connect` event after reconfigure

## Other changes

- Wrap `disconnect()` in try/except during device reconfiguration so a stale connection doesn't block re-setup
- Materialize `iter_devices()` to a list before iterating in `connect_all`/`disconnect_all` to prevent mutation-during-iteration errors
- Extract `_RECONNECT_DELAY` constant and use `device.disconnect()` instead of reaching into `device.connection.disconnect()` directly