### PR TITLE
Fix entity state stuck on UNKNOWN after setup abort

### DIFF
--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -85,27 +85,30 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
         if not device:
             _LOG.error("Failed to subscribe entities: no Kaleidescape configuration found for %s", device_id)
             return
-        # Re-register available entities so the ucapi framework can track them on future subscribes.
-        # _configure_new_kaleidescape already registered them, so this is a no-op here — the state
-        # sync will happen via on_kaleidescape_update once the connect task completes.
-        return
+    else:
+        # Re-register available entities if they were cleared (e.g. by a setup abort).
+        if device_config:
+            _register_available_entities(device_config, device)
+        if not device._connected:
+            loop.create_task(device.connect())
 
-    # Re-register available entities if they were cleared (e.g. by a setup abort).
-    if device_config:
-        _register_available_entities(device_config, device)
-
-    # Connect if not already connected
-    if not device._connected:
-        loop.create_task(device.connect())
-        return
-
-    # Sync current device state to all subscribed configured entities.
-    # Only runs when device was already registered and connected — newly created or
-    # reconnecting devices get state pushed via on_kaleidescape_update after connect.
+    # The ucapi framework moves entities from available → configured before calling this
+    # handler. If available_entities was empty at that point (e.g. cleared by a setup abort),
+    # the move failed and entities are missing from configured. Fix that up now that
+    # _register_available_entities has restored them.
     for entity_id in entity_ids:
-        entity = api.configured_entities.get(entity_id)
-        if entity:
-            _update_entity_attributes(entity_id, entity, device.attributes)
+        if not api.configured_entities.contains(entity_id):
+            entity = api.available_entities.get(entity_id)
+            if entity:
+                api.configured_entities.add(entity)
+
+    # Sync current device state for already-connected devices. Newly created or reconnecting
+    # devices get state pushed via on_kaleidescape_update after connect completes.
+    if device._connected:
+        for entity_id in entity_ids:
+            entity = api.configured_entities.get(entity_id)
+            if entity:
+                _update_entity_attributes(entity_id, entity, device.attributes)
 
 
 def _update_entity_attributes(entity_id: str, entity, attributes: dict):

--- a/intg-kaleidescape/driver.py
+++ b/intg-kaleidescape/driver.py
@@ -73,31 +73,39 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
     if not entity_ids:
         return
 
-    # Assume all entities share the same device
-    first_entity = api.configured_entities.get(entity_ids[0])
-    if not first_entity:
-        _LOG.error("First entity %s not found in configured_entities", entity_ids[0])
-        return
-
-    device_id = config.extract_device_id(first_entity)
+    # Extract device_id directly from entity_id (e.g. "media_player.ABC123" -> "ABC123")
+    device_id = entity_ids[0].split(".", 1)[1]
     device = get_device(device_id)
+    device_config = config.devices.get(device_id)
 
     if not device:
-        fallback_device = config.devices.get(device_id)
-        if fallback_device:
-            _configure_new_kaleidescape(fallback_device, connect=True)
-        else:
+        if device_config:
+            _configure_new_kaleidescape(device_config, connect=True)
+            device = get_device(device_id)
+        if not device:
             _LOG.error("Failed to subscribe entities: no Kaleidescape configuration found for %s", device_id)
+            return
+        # Re-register available entities so the ucapi framework can track them on future subscribes.
+        # _configure_new_kaleidescape already registered them, so this is a no-op here — the state
+        # sync will happen via on_kaleidescape_update once the connect task completes.
         return
 
-    for entity_id in entity_ids:
-        _LOG.debug("entity id = %s", entity_id)
-        entity = api.configured_entities.get(entity_id)
-        if not entity:
-            continue
+    # Re-register available entities if they were cleared (e.g. by a setup abort).
+    if device_config:
+        _register_available_entities(device_config, device)
 
-        # Handle media_player or remote entities
-        _update_entity_attributes(entity_id, entity, device.attributes)
+    # Connect if not already connected
+    if not device._connected:
+        loop.create_task(device.connect())
+        return
+
+    # Sync current device state to all subscribed configured entities.
+    # Only runs when device was already registered and connected — newly created or
+    # reconnecting devices get state pushed via on_kaleidescape_update after connect.
+    for entity_id in entity_ids:
+        entity = api.configured_entities.get(entity_id)
+        if entity:
+            _update_entity_attributes(entity_id, entity, device.attributes)
 
 
 def _update_entity_attributes(entity_id: str, entity, attributes: dict):

--- a/intg-kaleidescape/setup_flow.py
+++ b/intg-kaleidescape/setup_flow.py
@@ -9,10 +9,8 @@ import logging
 
 import config
 import ucapi
-from api import api
 from device import KaleidescapeInfo
 from discover import discover_kaleidescape_device, fetch_device_info
-from registry import clear_devices
 
 _LOG = logging.getLogger(__name__)
 
@@ -55,7 +53,7 @@ async def driver_setup_handler(msg: ucapi.SetupDriver) -> ucapi.SetupAction:
         return await handle_user_data_response(msg)
     if isinstance(msg, ucapi.AbortDriverSetup):
         _LOG.info("Setup was aborted with code: %s", msg.error)
-        clear_devices()
+        return ucapi.SetupError()
 
     _LOG.error("Error during setup")
     return ucapi.SetupError()
@@ -74,9 +72,6 @@ async def handle_driver_setup(msg: ucapi.DriverSetupRequest) -> ucapi.SetupActio
 
     if msg.reconfigure:
         _LOG.info("Starting reconfiguration")
-
-    api.available_entities.clear()
-    api.configured_entities.clear()
 
     if msg.setup_data.get("manual") == "true":
         _LOG.info("Entering manual setup settings")


### PR DESCRIPTION
## Summary

- Fix `on_subscribe_entities` to use device registry and config as source of truth instead of `api.configured_entities`, matching the pattern used by the ucapi-framework and the official AppleTV integration
- Stop clearing entity stores during setup start and abort — the official AppleTV integration, ucapi-framework (used by arcam, madVR, and others), and direct integrations like madVR all leave entity stores intact during setup, and none of them have this issue
- When the framework's entity move fails (because available was previously cleared), manually restore entities into `configured_entities` so state updates can be delivered

## Problem

After setting up a device, aborting a reconfiguration, and then subscribing entities, both the media player and remote entities would show UNKNOWN state permanently. This happened because:

1. `handle_driver_setup` cleared `available_entities` at the start of every setup attempt
2. On abort, `clear_devices()` also wiped the device registry
3. When the Remote later sent a subscribe request, the ucapi framework couldn't find entities in `available_entities` to move into `configured_entities`
4. `on_subscribe_entities` then failed because it depended on `configured_entities` for device lookup
5. The device connected and emitted state updates, but they were all silently dropped

## Validation steps

- Set up integration with a Kaleidescape device
- Start reconfiguration, then abort
- Add entities — they should show correct state (OFF/STANDBY), not UNKNOWN
- Verify normal setup flow still works (fresh setup, add entities immediately)
- Verify standby/wake cycle reconnects and updates state correctly